### PR TITLE
Fixing New Line feed in Sigfox AT responses

### DIFF
--- a/IO_WSSFM10.cpp
+++ b/IO_WSSFM10.cpp
@@ -48,7 +48,9 @@ String IO_WSSFM10::getData(){
 
 	while(Sigfox.available()){
 		output = Sigfox.read();
-		data += output;
+		if (output!=0x0A){
+      			data += output;
+    		}
 		delay(10);
 	}	
 


### PR DESCRIPTION
Sigfox messages by default are ended with a new line feed. This will make an issue if you want to organize your output in the way you want. E.g. if you want ID and PAC to be in the same line separated by a comma (to be in a format of CSV file, so that it could be exported as a list.). A benefit of this change could be having a list of ID/PAC in CSV format, so that you can do a bulk register on the backend.

I recorded a Sigfox response to getID() function with a logic analyzer and this is the result (some parts are covered due to privacy).
`https://pasteboard.co/I87o12ZM.png`
Here you can find ASCII table as well for all characters, including 0x0A: `http://www.asciitable.com/`
To solve this issue, a small change is needed that is suggested by this pull request.

```
// get data
String getData(){
  String data = "";
  char output;

  while (!Sigfox.available()){
     blink();
  }

  while(Sigfox.available()){
    output = Sigfox.read();
    if (output!=0x0A){
      data += output;
    }
    
    delay(10);
  }

  return data;  
}
```

A quick test with updated getData() could be this one (with old getData() you cannot print ID & PAC in one line in the following example):
```
//Get Sigfox ID & PAC
String getID_PAC(){
  Sigfox.print("AT$I=10\n");  
  String id = getData();
  delay(100);
  Sigfox.print("AT$I=11\n");
  String pac= getData();
  delay(100);
  if(DEBUG){
    Serial.println("ID,PAC: "+id+", "+pac);
  }

  //return id;
}
```