### PR TITLE
Update IO_WSSFM10.cpp

### DIFF
--- a/IO_WSSFM10.cpp
+++ b/IO_WSSFM10.cpp
@@ -48,7 +48,7 @@ String IO_WSSFM10::getData(){
 
 	while(Sigfox.available()){
 		output = Sigfox.read();
-		if ((output!=0x0A)&&(output!=0x0D)){//0x0A Line feed | 0x0D Carriage return
+		if ((output != 0x0A) && (output != 0x0D)){//0x0A Line feed | 0x0D Carriage return
 			data += output;
     	}
 

--- a/IO_WSSFM10.cpp
+++ b/IO_WSSFM10.cpp
@@ -48,7 +48,7 @@ String IO_WSSFM10::getData(){
 
 	while(Sigfox.available()){
 		output = Sigfox.read();
-		if (output != 0x0A){ // i.e. line feed
+		if ((output!=0x0A)&&(output!=0x0D)){//0x0A Line feed | 0x0D Carriage return
 			data += output;
     	}
 


### PR DESCRIPTION
Carriage return (CR) is also ignored, beside Line Feed (LF). Carriage return was also making some issues with formatting of the text when copied/forwarded to other editors.